### PR TITLE
lookup column management

### DIFF
--- a/scripts/create_lookup_column.sql
+++ b/scripts/create_lookup_column.sql
@@ -5,19 +5,20 @@ as $$
 declare
 	column_exists int;
 begin
-		execute format('SELECT count(1) 
-										FROM information_schema.columns 
+		execute format('SELECT count(1)
+										FROM information_schema.columns
 										WHERE table_name=%L and table_schema=%L and column_name=%L',
-									collection,schema,key) into column_exists;
+									collection,schema,'lookup_' || key) into column_exists;
 
 		if column_exists < 1 then
 			-- add the column
-			execute format('alter table %s.%s add column %s text', schema, collection,key);
+			execute format('alter table %s.%s add column %s text', schema, collection, 'lookup_' || key);
+
 			-- fill it
-			execute format('update %s.%s set %s = body ->> %L', schema, collection, key, key);
+			execute format('update %s.%s set %s = body ->> %L', schema, collection, 'lookup_' || key, key);
 
 			-- index it
-			execute format('create index on %s.%s(%s)', schema,collection,key);
+			execute format('create index on %s.%s(%s)', schema, collection, 'lookup_' || key);
 		end if;
 		res := true;
 end;

--- a/scripts/drop_lookup_columns.sql
+++ b/scripts/drop_lookup_columns.sql
@@ -1,9 +1,9 @@
 set search_path=dox;
 drop function if exists drop_lookup_columns(varchar, varchar);
 create function drop_lookup_columns(
-  collection varchar,
-  schema varchar default 'public',
-  out res bool
+	collection varchar,
+	schema varchar default 'public',
+	out res bool
 )
 as $$
 declare lookup text;
@@ -12,8 +12,8 @@ begin
 										FROM information_schema.columns
 										WHERE table_name=%L AND table_schema=%L AND column_name LIKE %L',
 									collection,schema,'lookup%') loop
-      execute format('alter table %s.%s drop column %I', schema, collection, lookup);
-    end loop;
+			execute format('alter table %s.%s drop column %I', schema, collection, lookup);
+		end loop;
 
 		res := true;
 end;

--- a/scripts/drop_lookup_columns.sql
+++ b/scripts/drop_lookup_columns.sql
@@ -1,0 +1,20 @@
+set search_path=dox;
+drop function if exists drop_lookup_columns(varchar, varchar);
+create function drop_lookup_columns(
+  collection varchar,
+  schema varchar default 'public',
+  out res bool
+)
+as $$
+declare lookup text;
+begin
+		for lookup in execute format('SELECT column_name
+										FROM information_schema.columns
+										WHERE table_name=%L AND table_schema=%L AND column_name LIKE %L',
+									collection,schema,'lookup%') loop
+      execute format('alter table %s.%s drop column %I', schema, collection, lookup);
+    end loop;
+
+		res := true;
+end;
+$$ language plpgsql;

--- a/scripts/ends_with.sql
+++ b/scripts/ends_with.sql
@@ -1,24 +1,21 @@
 set search_path=dox;
-drop function if exists ends_with(varchar, varchar, varchar, varchar, bool);
+drop function if exists ends_with(varchar, varchar, varchar, varchar);
 create function ends_with(
-	collection varchar, 
-	key varchar, 
-	term varchar, 
-	schema varchar default 'public', 
-	migrate bool default false
+	collection varchar,
+	key varchar,
+	term varchar,
+	schema varchar default 'public'
 )
 returns setof jsonb
 as $$
 declare
 	search_param text := '%' || term;
 begin
-	
-	-- is there a column with this name?
-	if migrate then
-		perform dox.create_lookup_column(collection => collection, schema => schema, key => key);
-	end if;
 
-	return query 
-	execute format('select body from %s.%s where %s ilike %L',schema,collection,key,search_param);
+	-- ensure we have the lookup column created if it doesn't already exist
+	perform dox.create_lookup_column(collection => collection, schema => schema, key => key);
+
+	return query
+	execute format('select body from %s.%s where %s ilike %L',schema,collection,'lookup_' || key,search_param);
 end;
 $$ language plpgsql;

--- a/scripts/init.sql
+++ b/scripts/init.sql
@@ -5,7 +5,7 @@ create schema dox;
 drop table if exists dox._opts;
 create table dox._opts(
 	id serial primary key,
-	search_args text[],
+	search_args text[]
 );
 
 insert into dox._opts(search_args)

--- a/scripts/starts_with.sql
+++ b/scripts/starts_with.sql
@@ -1,24 +1,21 @@
 set search_path=dox;
-drop function if exists starts_with(varchar, varchar, varchar, varchar, bool);
+drop function if exists starts_with(varchar, varchar, varchar, varchar);
 create function starts_with(
-	collection varchar, 
-	key varchar, 
-	term varchar, 
-	schema varchar default 'public', 
-	migrate bool default false
+	collection varchar,
+	key varchar,
+	term varchar,
+	schema varchar default 'public'
 )
 returns setof jsonb
 as $$
 declare
 	search_param text := term || '%';
 begin
-	
-	-- is there a column with this name?
-	if migrate then
-		perform dox.create_lookup_column(collection => collection, schema => schema, key => key);
-	end if;
 
-	return query 
-	execute format('select body from %s.%s where %s ilike %L',schema,collection,key,search_param);
+	-- ensure we have the lookup column created if it doesn't already exist
+	perform dox.create_lookup_column(collection => collection, schema => schema, key => key);
+
+	return query
+	execute format('select body from %s.%s where %s ilike %L',schema,collection,'lookup_' || key,search_param);
 end;
 $$ language plpgsql;


### PR DESCRIPTION
* consistent nomenclature
* let create_lookup_column handle the existence check instead of forcing a `migrate` param the first time
* clean up lookups